### PR TITLE
Add setuptools to the installation requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,8 @@ LONG_DESCRIPTION = open('README.md').read()
 
 INSTALL_REQUIRES = [
     'google-api-python-client',
-    'google-auth-httplib2'
+    'google-auth-httplib2',
+    'setuptools'
 ]
 
 


### PR DESCRIPTION
`setuptools` is a dependency of this package, as it is used in
`version.py`. When building applications with this package as
dependency, the applications need to have `setuptools` as an additional
dependency, eventough it is this package's dependency.

By adding `setuptools` to the list of installation requirements, this
package becomes self-contained.

Resolves #2 