### PR TITLE
Fix usecase for ImageButton with icon(_url) and name

### DIFF
--- a/src/hangouts_helper/message.py
+++ b/src/hangouts_helper/message.py
@@ -1,5 +1,4 @@
 from enum import Enum
-from collections import Iterable
 
 
 class ImageStyle(Enum):
@@ -263,12 +262,13 @@ class ImageButton(OnClickMixin):
         self.name = name
 
     def output(self):
+        button = {}
         if self.icon is not None:
             button = {'icon': self.icon.value}
         elif self.icon_url is not None:
             button = {'iconUrl': self.icon_url}
         if self.name is not None:
-            button = {'name': self.name}
+            button['name'] = self.name
         self._update_on_click(button)
         return {'imageButton': button}
 

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -3,7 +3,7 @@ import pytest
 from collections import OrderedDict
 
 from hangouts_helper.message import (Message, Card, CardHeader, Section,
-    Image, KeyValue, ButtonList, TextButton)
+    Image, KeyValue, ButtonList, TextButton, ImageButton)
 
 
 @pytest.fixture
@@ -94,6 +94,16 @@ def test_section_without_header():
         }]
     }
     assert section.output() == expected
+
+def test_image_button_with_link_and_name():
+    button = ImageButton(icon_url="http://example.com/logo.png", name="My Tooltip")
+    expected = {
+        'imageButton': {
+            'iconUrl': 'http://example.com/logo.png',
+            'name': 'My Tooltip'
+        }
+    }
+    assert button.output() == expected
 
 def test_pizza_bot_full_example(pizza_bot_message):
     message = Message()


### PR DESCRIPTION
Hi Chris,
Thanks for this great library! It makes my code to create a message for Hangouts Chat so much more readable :)
I found a small issue: it's not possible to create an ImageButton with both a icon(_url) and a name. The use case is that the name will be a tooltip for the image, when viewing the message in the browser. I've created this patch, including a test case that does fail without the fix.
Can you please merge and release a new version or give feedback if you do not agree with this proposal?
Thanks, Erik